### PR TITLE
Update .scrutinizer.yml

### DIFF
--- a/example/scrutinizer/.scrutinizer.yml
+++ b/example/scrutinizer/.scrutinizer.yml
@@ -16,6 +16,9 @@ build:
                     # version: 8.1.17
                     # version: 8.2.4
         analysis:
+            environment:
+                php:
+                    version: 8.3.3
             tests:
                 override:
                     - php-scrutinizer-run


### PR DESCRIPTION
Lyckas inte köra analys-noden utan att specificera PHP för den. Scrutinizer går tillbaka till PHP7 och composer 1.